### PR TITLE
Tab Fix

### DIFF
--- a/src/app/components/number-grid/number-grid.component.ts
+++ b/src/app/components/number-grid/number-grid.component.ts
@@ -49,6 +49,8 @@ export class NumberGridComponent implements OnInit, OnDestroy {
   private _cursorTimelines: gsap.core.Timeline[] = [];
   private resizeSubscription: Subscription | null = null;
   private _binnedPositions: Set<number> = new Set<number>();
+  private _isResetting = false; // Add a flag to track if a reset is already in progress
+  private _resetId = 0; // Add a counter to track reset operations
 
   constructor(
     private timeService: TimeService,
@@ -180,24 +182,17 @@ export class NumberGridComponent implements OnInit, OnDestroy {
     if (!document.hidden) {
       // Tab has become visible again
       console.log('Tab visibility changed to visible - resetting everything');
-      this.resetEverything();
+      // Only reset if we're not already in the middle of a reset
+      if (!this._isResetting) {
+        this.resetEverything();
+      } else {
+        console.log('Reset already in progress, skipping redundant reset');
+      }
       
       // Handle any animations that might have been in progress
       if (this.isAnimating) {
         this.endAnimation();
       }
-      
-      // Start with clean time selection after reset
-      setTimeout(() => {
-        this.beginAnimation();
-        this.quickInitialTimeSelection().then(() => {
-          this.endAnimation();
-          console.log('Time selection refreshed after tab switch');
-        }).catch(err => {
-          console.error('Error refreshing time selection after tab switch:', err);
-          this.endAnimation();
-        });
-      }, 1000);
     }
   }
 
@@ -1666,301 +1661,290 @@ export class NumberGridComponent implements OnInit, OnDestroy {
   }
   
   private async regenerateGridWithCorrectTime(): Promise<void> {
-    // Get the current numbers that were visible before bins
-    const oldNumbers = [...this.numbers];
-    const oldNumberCells = document.querySelectorAll('.number-cell');
-    
-    // Update our binned positions tracking by checking just the models, not the DOM
-    // This way we're tracking which positions/indices are binned, not which DOM elements
-    oldNumbers.forEach((num, index) => {
-      // If a number has zero opacity, consider it binned
-      if (num.opacity === 0) {
-        this._binnedPositions.add(index);
-      }
-    });
-    
-    console.log(`Tracking ${this._binnedPositions.size} binned positions that will stay hidden in model`);
-    
-    // Only clone visible cells for the transition
-    const visibleOldNumbers = Array.from(oldNumberCells).filter((cell, index) => 
-      !this._binnedPositions.has(index)
-    );
-    
-    // Clear any existing GSAP animations on numbers
-    gsap.killTweensOf(this.numbers);
-    
-    // Take a snapshot of visible elements for animation
-    const numberClones: {element: HTMLElement, rect: DOMRect}[] = [];
-    
-    visibleOldNumbers.forEach(element => {
-      const rect = element.getBoundingClientRect();
-      numberClones.push({
-        element: element as HTMLElement,
-        rect: rect
-      });
-    });
-    
-    console.log(`Created ${numberClones.length} clones for transition animation`);
-    
-    // Initialize new grid
-    this.initializeGrid();
-    
-    // *** CRITICAL: Set the opacity of the binned positions to 0 in the new model ***
-    // This prevents them from showing up during transitions, but allows DOM elements to be reused
-    this._binnedPositions.forEach(index => {
-      if (index < this.numbers.length) {
-        this.numbers[index].opacity = 0;
-      }
-    });
-    
-    // Remove duplicate declaration and code
-    // const visibleOldNumbers = Array.from(oldNumberCells).filter((cell, index) => 
-    //  !this._binnedPositions.has(index)
-    // );
-    
-    // Clear any existing GSAP animations on numbers
-    this.numbers.forEach(num => {
-      gsap.killTweensOf(num);
-    });
-    
-    // Reset all number properties to clear any lingering animations
-    this.clearSelections();
-    
-    // SEVERANCE-STYLE TRANSITION: Create a "data refinement" effect
-    // --------------------------------------------------------------
-    // First capture the current state of the grid to create a seamless transition
-    const gridContainer = document.querySelector('.grid-container') as HTMLElement;
-    if (gridContainer) {
-      // Create a snapshot overlay for the transition effect
-      const transitionOverlay = document.createElement('div');
-      transitionOverlay.className = 'severance-transition-overlay';
-      transitionOverlay.style.position = 'absolute';
-      transitionOverlay.style.top = '0';
-      transitionOverlay.style.left = '0';
-      transitionOverlay.style.width = '100%';
-      transitionOverlay.style.height = '100%';
-      transitionOverlay.style.pointerEvents = 'none';
-      transitionOverlay.style.zIndex = '5000';
-      transitionOverlay.style.opacity = '1';
-      transitionOverlay.style.background = 'transparent';
-      
-      // Only clone cells that were visible (not already binned)
-      visibleOldNumbers.forEach(cell => {
-        const rect = cell.getBoundingClientRect();
-        const gridRect = gridContainer.getBoundingClientRect();
-        
-        // Position relative to grid container
-        const clone = cell.cloneNode(true) as HTMLElement;
-        clone.style.position = 'absolute';
-        clone.style.left = `${rect.left - gridRect.left}px`;
-        clone.style.top = `${rect.top - gridRect.top}px`;
-        clone.style.width = `${rect.width}px`;
-        clone.style.height = `${rect.height}px`;
-        clone.style.pointerEvents = 'none';
-        clone.style.transition = 'none';
-        
-        transitionOverlay.appendChild(clone);
-      });
-      
-      // Add the overlay to the grid container
-      gridContainer.appendChild(transitionOverlay);
-      
-      // Create a brief "severance" effect with scan lines
-      const scanLines = document.createElement('div');
-      scanLines.className = 'severance-scan-lines';
-      scanLines.style.position = 'absolute';
-      scanLines.style.top = '0';
-      scanLines.style.left = '0';
-      scanLines.style.width = '100%';
-      scanLines.style.height = '100%';
-      scanLines.style.backgroundImage = 'linear-gradient(transparent 50%, rgba(0, 255, 255, 0.03) 50%)';
-      scanLines.style.backgroundSize = '100% 4px';
-      scanLines.style.pointerEvents = 'none';
-      scanLines.style.zIndex = '5001';
-      scanLines.style.opacity = '0';
-      
-      gridContainer.appendChild(scanLines);
-      
-      // Create a "data processing" line
-      const dataLine = document.createElement('div');
-      dataLine.className = 'severance-data-line';
-      dataLine.style.position = 'absolute';
-      dataLine.style.left = '0';
-      dataLine.style.top = '0';
-      dataLine.style.width = '100%';
-      dataLine.style.height = '2px';
-      dataLine.style.backgroundColor = 'rgba(0, 255, 255, 0.6)';
-      dataLine.style.boxShadow = '0 0 10px rgba(0, 255, 255, 0.8)';
-      dataLine.style.zIndex = '5002';
-      dataLine.style.transform = 'translateY(-10px)';
-      
-      gridContainer.appendChild(dataLine);
-      
-      // Animate the transition
-      const tl = gsap.timeline({
-        onComplete: () => {
-          // Remove transition elements when animation is complete
-          gridContainer.removeChild(transitionOverlay);
-          gridContainer.removeChild(scanLines);
-          gridContainer.removeChild(dataLine);
-        }
-      });
-      
-      // Step 1: Show scan lines and start data processing
-      tl.to(scanLines, {
-        opacity: 0.9,
-        duration: 0.3,
-        ease: 'power1.in'
-      });
-      
-      // Step 2: Animate the data processing line downward
-      tl.to(dataLine, {
-        top: '100%',
-        duration: 1.3,
-        ease: 'power1.inOut'
-      }, 0.1);
-      
-      // Step 3: Fade out the old numbers with a digital distortion effect
-      const clones = transitionOverlay.querySelectorAll('.number-cell');
-      clones.forEach((clone, i) => {
-        // Create a staggered, glitchy fade out
-        const delay = 0.1 + (i % 10) * 0.02;
-        
-        tl.to(clone, {
-          opacity: 0,
-          filter: 'blur(2px)',
-          y: '+=' + (Math.random() * 2 - 1),
-          x: '+=' + (Math.random() * 2 - 1),
-          scale: 0.9,
-          duration: 0.4,
-          ease: 'power1.in',
-          delay: delay
-        }, 0.3);
-      });
-      
-      // Step 4: Fade out scan lines
-      tl.to(scanLines, {
-        opacity: 0,
-        duration: 0.3,
-        ease: 'power1.out'
-      }, 1.2);
-    }
-    
-    // Generate new grid with fresh numbers
-    this.initializeGrid();
-    
-    // CRITICAL FIX: Immediately hide binned positions right after grid initialization
-    // This ensures they never appear even for a split second
-    if (this._binnedPositions.size > 0) {
-      console.log(`Immediately updating opacity for ${this._binnedPositions.size} binned numbers in new grid`);
-      
-      this._binnedPositions.forEach(pos => {
-        if (pos < this.numbers.length) {
-          // Update only the model, not the DOM visibility
-          this.numbers[pos].opacity = 0;
-        }
-      });
-    }
-    
-    // CRITICAL FIX: Update binned positions in the model, but don't hide DOM elements
-    // This ensures they are tracked as binned but can be reused with new values
-    if (this._binnedPositions.size > 0) {
-      console.log(`Setting opacity to 0 for ${this._binnedPositions.size} binned positions in model`);
-      
-      this._binnedPositions.forEach(pos => {
-        if (pos < this.numbers.length) {
-          // Update only the model, not the DOM, so elements can be reused
-          this.numbers[pos].opacity = 0;
-        }
-      });
-    }
-    
-    // Get current time
-    const now = new Date();
-    const hour = now.getHours() % 12 || 12;
-    const minute = now.getMinutes();
-    const timeDigits = [
-      Math.floor(hour / 10),
-      hour % 10,
-      Math.floor(minute / 10),
-      minute % 10
-    ];
-    
-    console.log(`Verifying grid has correct time: ${hour}:${minute.toString().padStart(2, '0')}`);
-    
-    // Verify time digits are correctly placed
-    if (!this.verifyTimeDigitsInGrid(timeDigits)) {
-      console.error('Time digits verification failed after regeneration');
-      
-      // Try direct manual placement of time digits as a last resort
-      const timePatternCells = this.numbers.filter(n => n.isTimePattern);
-      if (timePatternCells.length === 4) {
-        // Directly assign the correct time digits
-        for (let i = 0; i < 4; i++) {
-          timePatternCells[i].value = timeDigits[i];
-        }
-        console.log('Manually assigned time digits to pattern cells');
-      } else {
-        // If we still can't place the time digits, try one more regeneration
-        console.log('Retrying grid regeneration');
-        
-        // Kill any animations and reinitialize
-        this.numbers.forEach(num => {
-          gsap.killTweensOf(num);
+    try {
+      // Get numbers that are currently visible (not binned) for transition effect
+      const oldGrid = document.querySelector('.number-grid') as HTMLElement;
+      const visibleOldNumbers: HTMLElement[] = [];
+      if (oldGrid) {
+        const cells = oldGrid.querySelectorAll('.number-cell') as NodeListOf<HTMLElement>;
+        Array.from(cells).forEach(cell => {
+          // Only include visible cells
+          if (cell.style.visibility !== 'hidden' && cell.style.opacity !== '0') {
+            visibleOldNumbers.push(cell);
+          }
         });
-        this.clearSelections();
-        this.initializeGrid();
-        
-        // Final verification
-        if (!this.verifyTimeDigitsInGrid(timeDigits)) {
-          console.error('Failed to place time digits after multiple attempts');
-        }
       }
-    }
-    
-    // Apply model updates for binned numbers after animation
-    setTimeout(() => {
-      // Hide numbers in the model that were previously binned
+      
+      // Get the current time (using a different variable name)
+      const currentDate = new Date();
+      const currentTime = {
+        hour: currentDate.getHours() % 12 || 12, // 12-hour format
+        minute: currentDate.getMinutes()
+      };
+      
+      // If there's an ongoing animation, end it
+      if (this.isAnimating) {
+        console.log('Animation still active during grid regeneration, ending it...');
+        this.endAnimation();
+      }
+      
+      // Reset all number properties to clear any lingering animations
+      this.numbers.forEach(num => {
+        num.isSelected = false;
+        num.isHovered = false;
+        num.opacity = 1;
+        num.scale = 1;
+        num.x = 0;
+        num.y = 0;
+        num.rotation = 0;
+      });
+      
+      // --------------------------------------------------------------
+      // First capture the current state of the grid to create a seamless transition
+      const gridContainer = document.querySelector('.grid-container') as HTMLElement;
+      if (gridContainer) {
+        // Clean up any existing transition overlays in the grid container
+        const existingOverlays = gridContainer.querySelectorAll('.severance-transition-overlay, .severance-scan-lines, .severance-data-line');
+        existingOverlays.forEach(overlay => {
+          if (overlay.parentNode) {
+            overlay.parentNode.removeChild(overlay);
+          }
+        });
+        
+        // Create a snapshot overlay for the transition effect
+        const transitionOverlay = document.createElement('div');
+        transitionOverlay.className = 'severance-transition-overlay';
+        transitionOverlay.style.position = 'absolute';
+        transitionOverlay.style.top = '0';
+        transitionOverlay.style.left = '0';
+        transitionOverlay.style.width = '100%';
+        transitionOverlay.style.height = '100%';
+        transitionOverlay.style.pointerEvents = 'none';
+        transitionOverlay.style.zIndex = '5000';
+        transitionOverlay.style.opacity = '1';
+        transitionOverlay.style.background = 'transparent';
+        
+        // Only clone cells that were visible (not already binned)
+        visibleOldNumbers.forEach(cell => {
+          const rect = cell.getBoundingClientRect();
+          const gridRect = gridContainer.getBoundingClientRect();
+          
+          // Position relative to grid container
+          const clone = cell.cloneNode(true) as HTMLElement;
+          clone.style.position = 'absolute';
+          clone.style.left = `${rect.left - gridRect.left}px`;
+          clone.style.top = `${rect.top - gridRect.top}px`;
+          clone.style.width = `${rect.width}px`;
+          clone.style.height = `${rect.height}px`;
+          clone.style.pointerEvents = 'none';
+          clone.style.transition = 'none';
+          
+          transitionOverlay.appendChild(clone);
+        });
+        
+        // Add the overlay to the grid container
+        gridContainer.appendChild(transitionOverlay);
+        
+        // Create a brief "severance" effect with scan lines
+        const scanLines = document.createElement('div');
+        scanLines.className = 'severance-scan-lines';
+        scanLines.style.position = 'absolute';
+        scanLines.style.top = '0';
+        scanLines.style.left = '0';
+        scanLines.style.width = '100%';
+        scanLines.style.height = '100%';
+        scanLines.style.backgroundImage = 'linear-gradient(transparent 50%, rgba(0, 255, 255, 0.03) 50%)';
+        scanLines.style.backgroundSize = '100% 4px';
+        scanLines.style.pointerEvents = 'none';
+        scanLines.style.zIndex = '5001';
+        scanLines.style.opacity = '0';
+        
+        gridContainer.appendChild(scanLines);
+        
+        // Create a "data processing" line
+        const dataLine = document.createElement('div');
+        dataLine.className = 'severance-data-line';
+        dataLine.style.position = 'absolute';
+        dataLine.style.left = '0';
+        dataLine.style.top = '0';
+        dataLine.style.width = '100%';
+        dataLine.style.height = '2px';
+        dataLine.style.backgroundColor = 'rgba(0, 255, 255, 0.6)';
+        dataLine.style.boxShadow = '0 0 10px rgba(0, 255, 255, 0.8)';
+        dataLine.style.zIndex = '5002';
+        dataLine.style.transform = 'translateY(-10px)';
+        
+        gridContainer.appendChild(dataLine);
+        
+        // Animate the transition
+        const tl = gsap.timeline({
+          onComplete: () => {
+            // Remove transition elements when animation is complete
+            gridContainer.removeChild(transitionOverlay);
+            gridContainer.removeChild(scanLines);
+            gridContainer.removeChild(dataLine);
+          }
+        });
+        
+        // Step 1: Show scan lines and start data processing
+        tl.to(scanLines, {
+          opacity: 0.9,
+          duration: 0.3,
+          ease: 'power1.in'
+        });
+        
+        // Step 2: Animate the data processing line downward
+        tl.to(dataLine, {
+          top: '100%',
+          duration: 1.3,
+          ease: 'power1.inOut'
+        }, 0.1);
+        
+        // Step 3: Fade out the old numbers with a digital distortion effect
+        const clones = transitionOverlay.querySelectorAll('.number-cell');
+        clones.forEach((clone, i) => {
+          // Create a staggered, glitchy fade out
+          const delay = 0.1 + (i % 10) * 0.02;
+          
+          tl.to(clone, {
+            opacity: 0,
+            filter: 'blur(2px)',
+            y: '+=' + (Math.random() * 2 - 1),
+            x: '+=' + (Math.random() * 2 - 1),
+            scale: 0.9,
+            duration: 0.4,
+            ease: 'power1.in',
+            delay: delay
+          }, 0.3);
+        });
+        
+        // Step 4: Fade out scan lines
+        tl.to(scanLines, {
+          opacity: 0,
+          duration: 0.3,
+          ease: 'power1.out'
+        }, 1.2);
+      }
+      
+      // Generate new grid with fresh numbers
+      this.initializeGrid();
+      
+      // CRITICAL FIX: Immediately hide binned positions right after grid initialization
+      // This ensures they never appear even for a split second
       if (this._binnedPositions.size > 0) {
-        console.log(`Setting opacity to 0 for ${this._binnedPositions.size} previously binned positions in model`);
+        console.log(`Immediately updating opacity for ${this._binnedPositions.size} binned numbers in new grid`);
+        
         this._binnedPositions.forEach(pos => {
-          // Only update the model to ensure cells can be reused with new values
-          if (this.numbers[pos]) {
+          if (pos < this.numbers.length) {
+            // Update only the model, not the DOM visibility
             this.numbers[pos].opacity = 0;
           }
         });
       }
-    }, 0);
-    
-    // Improved entry animations for all numbers
-    this.numbers.forEach((number, idx) => {
-      // CRITICAL FIX: Double-check binned positions before animation
-      // This ensures binned numbers never get animated into view
-      if (this._binnedPositions.has(idx)) {
-        // Set opacity to 0 in the model but don't change DOM visibility
-        number.opacity = 0;
-        return; // Skip animation entirely
-      }
       
-      // INSTANT APPEARANCE - No gradual animations
-      // Set all properties to their final values immediately
-      number.opacity = 0.7; // Final opacity
-      number.scale = 1;     // Final scale
-      number.y = 0;         // Final position
-      
-      // Only add the subtle floating animation for non-time pattern numbers
-      if (!number.isTimePattern) {
-        gsap.to(number, {
-          y: () => (Math.random() * 6 - 3),
-          duration: 2 + Math.random() * 2,
-          repeat: -1,
-          yoyo: true,
-          ease: 'sine.inOut'
+      // CRITICAL FIX: Update binned positions in the model, but don't hide DOM elements
+      // This ensures they are tracked as binned but can be reused with new values
+      if (this._binnedPositions.size > 0) {
+        console.log(`Setting opacity to 0 for ${this._binnedPositions.size} binned positions in model`);
+        
+        this._binnedPositions.forEach(pos => {
+          if (pos < this.numbers.length) {
+            // Update only the model, not the DOM, so elements can be reused
+            this.numbers[pos].opacity = 0;
+          }
         });
       }
-    });
-    
-    return Promise.resolve();
+      
+      // Get current time
+      const now = new Date();
+      const hour = now.getHours() % 12 || 12;
+      const minute = now.getMinutes();
+      const timeDigits = [
+        Math.floor(hour / 10),
+        hour % 10,
+        Math.floor(minute / 10),
+        minute % 10
+      ];
+      
+      console.log(`Verifying grid has correct time: ${hour}:${minute.toString().padStart(2, '0')}`);
+      
+      // Verify time digits are correctly placed
+      if (!this.verifyTimeDigitsInGrid(timeDigits)) {
+        console.error('Time digits verification failed after regeneration');
+        
+        // Try direct manual placement of time digits as a last resort
+        const timePatternCells = this.numbers.filter(n => n.isTimePattern);
+        if (timePatternCells.length === 4) {
+          // Directly assign the correct time digits
+          for (let i = 0; i < 4; i++) {
+            timePatternCells[i].value = timeDigits[i];
+          }
+          console.log('Manually assigned time digits to pattern cells');
+        } else {
+          // If we still can't place the time digits, try one more regeneration
+          console.log('Retrying grid regeneration');
+          
+          // Kill any animations and reinitialize
+          this.numbers.forEach(num => {
+            gsap.killTweensOf(num);
+          });
+          this.clearSelections();
+          this.initializeGrid();
+          
+          // Final verification
+          if (!this.verifyTimeDigitsInGrid(timeDigits)) {
+            console.error('Failed to place time digits after multiple attempts');
+          }
+        }
+      }
+      
+      // Apply model updates for binned numbers after animation
+      setTimeout(() => {
+        // Hide numbers in the model that were previously binned
+        if (this._binnedPositions.size > 0) {
+          console.log(`Setting opacity to 0 for ${this._binnedPositions.size} previously binned positions in model`);
+          this._binnedPositions.forEach(pos => {
+            // Only update the model to ensure cells can be reused with new values
+            if (this.numbers[pos]) {
+              this.numbers[pos].opacity = 0;
+            }
+          });
+        }
+      }, 0);
+      
+      // Improved entry animations for all numbers
+      this.numbers.forEach((number, idx) => {
+        // CRITICAL FIX: Double-check binned positions before animation
+        // This ensures binned numbers never get animated into view
+        if (this._binnedPositions.has(idx)) {
+          // Set opacity to 0 in the model but don't change DOM visibility
+          number.opacity = 0;
+          return; // Skip animation entirely
+        }
+        
+        // INSTANT APPEARANCE - No gradual animations
+        // Set all properties to their final values immediately
+        number.opacity = 0.7; // Final opacity
+        number.scale = 1;     // Final scale
+        number.y = 0;         // Final position
+        
+        // Only add the subtle floating animation for non-time pattern numbers
+        if (!number.isTimePattern) {
+          gsap.to(number, {
+            y: () => (Math.random() * 6 - 3),
+            duration: 2 + Math.random() * 2,
+            repeat: -1,
+            yoyo: true,
+            ease: 'sine.inOut'
+          });
+        }
+      });
+      
+      return Promise.resolve();
+    } catch (error) {
+      console.error('Error during grid regeneration:', error);
+      return Promise.reject(error);
+    }
   }
   
   private verifyTimeDigitsInGrid(timeDigits: number[]): boolean {
@@ -2233,7 +2217,16 @@ export class NumberGridComponent implements OnInit, OnDestroy {
   }
 
   private resetEverything(): void {
-    console.log('Performing complete reset of application state due to resize');
+    // Prevent multiple concurrent resets
+    if (this._isResetting) {
+      console.log('Reset already in progress, skipping redundant reset');
+      return;
+    }
+
+    // Set reset lock and generate a unique ID for this reset operation
+    this._isResetting = true;
+    const currentResetId = ++this._resetId;
+    console.log(`Performing complete reset of application state (ID: ${currentResetId})`);
     
     // First, check if we're in the middle of an animation
     if (this.isAnimating) {
@@ -2267,6 +2260,22 @@ export class NumberGridComponent implements OnInit, OnDestroy {
         overlay.parentNode.removeChild(overlay);
       }
     });
+
+    // Also remove any transition overlays
+    const transitionOverlays = document.querySelectorAll('body > div.severance-transition-overlay');
+    transitionOverlays.forEach(overlay => {
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+    });
+
+    // Remove any other high z-index elements that might have been left over
+    const highZIndexElements = document.querySelectorAll('body > div[style*="z-index: 5000"]');
+    highZIndexElements.forEach(element => {
+      if (element.parentNode) {
+        element.parentNode.removeChild(element);
+      }
+    });
     
     // Reset any number cells visibility
     const numberCells = document.querySelectorAll('.number-cell');
@@ -2278,20 +2287,32 @@ export class NumberGridComponent implements OnInit, OnDestroy {
     const now = new Date();
     this.lastCheckedMinute = now.getMinutes();
     
+    // Empty the numbers array before initializing a new grid
+    this.numbers = [];
+    
     // Finally, reinitialize the grid with new dimensions
     this.initializeGrid();
     
     // Start with quick initial time selection (without binning) after a delay
     // to give the DOM time to update
     setTimeout(() => {
+      // Check if this reset operation is still the most recent one
+      if (currentResetId !== this._resetId) {
+        console.log(`Reset ${currentResetId} was superseded by newer reset, skipping time selection`);
+        this._isResetting = false;
+        return;
+      }
+
       console.log('Starting initial time selection after reset');
       this.beginAnimation();
       this.quickInitialTimeSelection().then(() => {
         this.endAnimation();
         console.log('Initial time selection after reset complete');
+        this._isResetting = false; // Release the reset lock when done
       }).catch(err => {
         console.error('Error in initial time selection after reset:', err);
         this.endAnimation();
+        this._isResetting = false; // Release the reset lock even on error
       });
     }, 1000);
   }

--- a/src/app/services/location.service.ts
+++ b/src/app/services/location.service.ts
@@ -2,48 +2,73 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, catchError, map } from 'rxjs';
 
-interface IpapiResponse {
+interface GeoJsResponse {
   city: string;
   region: string;
-  country_name: string;
+  country: string;
 }
 
 @Injectable({
   providedIn: 'root'
 })
 export class LocationService {
-  private locationCache: string | null = null;
+  private readonly CACHE_KEY = 'severance-location-cache';
+  private readonly CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+  
   private readonly fallbackLocations = [
-    'Siena', 'Topeka', 'Helena', 'Boise', 'Denver'
+    'Siena', 'Topeka', 'Helena', 'Boise', 'Denver',
+    'Austin', 'Portland', 'Seattle', 'Chicago', 'Boston'
   ];
 
   constructor(private http: HttpClient) {}
 
   getLocation(): Observable<string> {
-    if (this.locationCache) {
-      return of(this.locationCache);
+    // Check cache first
+    const cachedLocation = this.getCachedLocation();
+    if (cachedLocation) {
+      return of(cachedLocation);
     }
 
-    // Using ipapi.co which supports HTTPS and doesn't require browser permissions
-    return this.http.get<IpapiResponse>('https://ipapi.co/json/')
-      .pipe(
-        map(response => {
-          if (response && response.city) {
-            this.locationCache = response.city;
-            return response.city;
-          } else {
-            return this.getRandomFallbackLocation();
-          }
-        }),
-        catchError(() => {
-          return of(this.getRandomFallbackLocation());
-        })
-      );
+    // Try geo.js.org - free, unlimited, and CORS enabled
+    return this.http.get<GeoJsResponse>('https://get.geojs.io/v1/ip/geo.json').pipe(
+      map(response => {
+        if (response?.city) {
+          this.cacheLocation(response.city);
+          return response.city;
+        }
+        return this.getRandomFallbackLocation();
+      }),
+      catchError(() => of(this.getRandomFallbackLocation()))
+    );
+  }
+
+  private getCachedLocation(): string | null {
+    const cached = localStorage.getItem(this.CACHE_KEY);
+    if (!cached) return null;
+
+    try {
+      const { location, timestamp } = JSON.parse(cached);
+      if (Date.now() - timestamp < this.CACHE_DURATION) {
+        return location;
+      }
+    } catch (e) {
+      console.error('Error parsing cached location:', e);
+    }
+    return null;
+  }
+
+  private cacheLocation(location: string): void {
+    const cache = {
+      location,
+      timestamp: Date.now()
+    };
+    localStorage.setItem(this.CACHE_KEY, JSON.stringify(cache));
   }
 
   private getRandomFallbackLocation(): string {
     const random = Math.floor(Math.random() * this.fallbackLocations.length);
-    this.locationCache = this.fallbackLocations[random];
-    return this.locationCache;
+    const location = this.fallbackLocations[random];
+    this.cacheLocation(location); // Cache the fallback location too
+    return location;
   }
 } 


### PR DESCRIPTION
The fix detects when you switch away from the tab and return, triggering a complete reset of the grid (similar to window resizing) that clears all animations, positions, and binned numbers, followed by a fresh time selection to ensure numbers don't stack up incorrectly when resuming the application.